### PR TITLE
Added configurable separator

### DIFF
--- a/key-tree-store.js
+++ b/key-tree-store.js
@@ -1,8 +1,9 @@
 var slice = Array.prototype.slice;
 
 // our constructor
-function KeyTreeStore() {
+function KeyTreeStore(separator) {
     this.storage = {};
+    this.separator = separator || '.';
 }
 
 // add an object to the store
@@ -31,7 +32,7 @@ KeyTreeStore.prototype.get = function (keypath) {
     var key;
 
     for (key in this.storage) {
-        if (!keypath || keypath === key || key.indexOf(keypath + '.') === 0) {
+        if (!keypath || keypath === key || key.indexOf(keypath + this.separator) === 0) {
             res = res.concat(this.storage[key]);
         }
     }
@@ -45,7 +46,7 @@ KeyTreeStore.prototype.getGrouped = function (keypath) {
     var key;
 
     for (key in this.storage) {
-        if (!keypath || keypath === key || key.indexOf(keypath + '.') === 0) {
+        if (!keypath || keypath === key || key.indexOf(keypath + this.separator) === 0) {
             res[key] = slice.call(this.storage[key]);
         }
     }
@@ -59,7 +60,7 @@ KeyTreeStore.prototype.getAll = function (keypath) {
     var key;
 
     for (key in this.storage) {
-        if (keypath === key || key.indexOf(keypath + '.') === 0) {
+        if (keypath === key || key.indexOf(keypath + this.separator) === 0) {
             res[key] = slice.call(this.storage[key]);
         }
     }

--- a/key-tree-store.js
+++ b/key-tree-store.js
@@ -1,9 +1,11 @@
 var slice = Array.prototype.slice;
 
 // our constructor
-function KeyTreeStore(separator) {
+function KeyTreeStore(options) {
+    options = options || {};
+
     this.storage = {};
-    this.separator = separator || '.';
+    this.separator = options.separator || '.';
 }
 
 // add an object to the store

--- a/test/index.js
+++ b/test/index.js
@@ -44,6 +44,48 @@ test('`add` should store objects', function (t) {
     t.end();
 });
 
+test('a different `separator` should be respected', function (t) {
+    var tree = new KeyTree('|');
+    var one = {id: 'one'};
+    var two = {id: 'two'};
+    var three = {id: 'three'};
+    var four = {id: 'four'};
+
+    tree.add('first', one);
+    tree.add('first|second', two);
+    tree.add('first|second', three);
+    tree.add('first|second|third', four);
+
+    t.equal(Object.keys(tree.storage).length, 3);
+
+    t.equal(tree.storage['first|second'].length, 2, 'should be two for `first|second` key');
+    t.equal(tree.get().length, 4, 'should return all');
+    t.equal(tree.get('first').length, 4, 'should be 4 that match');
+    t.equal(tree.get('first|second').length, 3, 'should be 3 that match');
+    t.equal(tree.get('first|second|third').length, 1, 'should be 1 that match');
+
+    t.equal(tree.get('second|third').length, 0, 'keypaths should start at the start');
+
+    t.equal(tree.get('first|seco').length, 0, 'keypaths must be the full path');
+
+    t.deepEqual(tree.getGrouped('first|second'), {
+        'first|second': [two, three],
+        'first|second|third': [four]
+    });
+
+    t.deepEqual(tree.getGrouped(), {
+        'first': [one],
+        'first|second': [two, three],
+        'first|second|third': [four]
+    });
+
+    tree.remove(two);
+    t.equal(tree.get('first').length, 3, 'should be 3 that match after removal');
+
+
+    t.end();
+});
+
 test('`run`', function (t) {
     var tree = new KeyTree();
     var oneRan, twoRan;


### PR DESCRIPTION
We use CouchDB a lot for document storage. CouchDB uses dots in some document property names, so we need a way to configure the separator for nested properties. This PR should enable us and others to use `ampersand-view` bindings with CouchDB.

In particular, CouchDB stores attachments with their file names, which normally contain dots:

````javascript
{
  "_id": "some_doc",
  "_attachments": {
    "some_file.jpg": {
      "content_type": "image/jpeg",
      "revpos": 13,
      "digest": "md5-Oa39RRTNvOpPUvhHI6fAwA==",
      "length": 231548,
      "stub": true
    },
    "some_other_file.doc": {
      // and so on...
    }
  }
}
````